### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/containerimage.yml
+++ b/.github/workflows/containerimage.yml
@@ -13,7 +13,7 @@ jobs:
       with:
         fetch-depth: 1
     - name: Publish frontend image to Registry
-      uses: elgohr/Publish-Docker-Github-Action@2.8
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: ${{ github.repository }}/frontend
         username: ${{ github.actor }}
@@ -34,7 +34,7 @@ jobs:
         rm icons.tar js.tar css.tar
         docker rm -v $CONTAINER
     - name: Publish backend image to Registry
-      uses: elgohr/Publish-Docker-Github-Action@2.8
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: ${{ github.repository }}/backend
         username: ${{ github.actor }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore